### PR TITLE
Added support for browsers where property obj.consturctor.name isn't supported

### DIFF
--- a/m3u.js
+++ b/m3u.js
@@ -32,7 +32,8 @@ M3U.prototype.set = function setProperty(key, value) {
 };
 
 M3U.prototype.addItem = function addItem(item) {
-  this.items[item.constructor.name].push(item);
+  var itemClassName = item.constructor.name || item.getClassName();
+  this.items[itemClassName].push(item);
 
   return this;
 };

--- a/m3u/Item.js
+++ b/m3u/Item.js
@@ -54,3 +54,7 @@ Item.prototype.setData = function setData(data) {
 Item.prototype.propertiesHasKey = function hasKey(key) {
   return Object.keys(this.properties).indexOf(key) > -1;
 };
+
+Item.prototype.getClassName = function getName() {
+  return this.constructor.toString().match(/function (\w*)/)[1];
+};


### PR DESCRIPTION
In IE for example, the property obj.consturctor.name is undefined. I added an alternate way to retrieve the constructor's name in that case
