### PR TITLE
Add support to remove a PlaylistItem by index

### DIFF
--- a/m3u.js
+++ b/m3u.js
@@ -44,6 +44,8 @@ M3U.prototype.addPlaylistItem = function addPlaylistItem(data) {
 M3U.prototype.removePlaylistItem = function removePlaylistItem(index) {
   if(index < this.items.PlaylistItem.length && index >= 0){
     this.items.PlaylistItem.splice(index, 1);
+  }else{
+  	throw new Error('item out of range');
   }
 };
 

--- a/m3u.js
+++ b/m3u.js
@@ -41,6 +41,12 @@ M3U.prototype.addPlaylistItem = function addPlaylistItem(data) {
   this.items.PlaylistItem.push(M3U.PlaylistItem.create(data));
 };
 
+M3U.prototype.removePlaylistItem = function removePlaylistItem(index) {
+  if(index < this.items.PlaylistItem.length && index >= 0){
+    this.items.PlaylistItem.splice(index, 1);
+  }
+};
+
 M3U.prototype.addMediaItem = function addMediaItem(data) {
   this.items.MediaItem.push(M3U.MediaItem.create(data));
 };

--- a/test/m3u.test.js
+++ b/test/m3u.test.js
@@ -41,6 +41,17 @@ describe('m3u', function() {
     });
   });
 
+  describe('#removePlaylistItem', function() {
+    it('should remove a PlaylistItem at a specifed index', function() {
+      var m3u = getM3u();
+
+      m3u.addPlaylistItem({});
+      m3u.removePlaylistItem(0);
+      m3u.items.PlaylistItem.length.should.eql(0);
+    });
+  });
+
+
   describe('#addMediaItem', function() {
     it('should create and add a MediaItem', function() {
       var m3u = getM3u();

--- a/test/m3u.test.js
+++ b/test/m3u.test.js
@@ -51,6 +51,17 @@ describe('m3u', function() {
     });
   });
 
+  describe('#removePlaylistItemOutOfRange', function() {
+    it('should thow an error when trying to remove a playlist item out of range', function() {
+      var m3u = getM3u();
+
+      m3u.addPlaylistItem({});
+      m3u.addPlaylistItem({});
+      m3u.removePlaylistItem(3);
+      m3u.items.PlaylistItem.length.should.eql(2);
+    });
+  });
+
 
   describe('#addMediaItem', function() {
     it('should create and add a MediaItem', function() {

--- a/test/m3u.test.js
+++ b/test/m3u.test.js
@@ -57,8 +57,16 @@ describe('m3u', function() {
 
       m3u.addPlaylistItem({});
       m3u.addPlaylistItem({});
-      m3u.removePlaylistItem(3);
-      m3u.items.PlaylistItem.length.should.eql(2);
+
+      var error = false;
+      try {
+      	m3u.removePlaylistItem(3);
+      }catch(e){
+      	error = true;
+      }
+
+      error.should.eql(true);
+     
     });
   });
 


### PR DESCRIPTION
This allows the user to programatically remove an item by index from the PlayListItems array.

Use case:
I'm generating a live m3u8 playlist and need to only have 100 items - by adding this method we can remove the first item (or any one that takes your desire) by passing the index to removePlaylistItem()