### PR TITLE
few extra features

### DIFF
--- a/m3u.js
+++ b/m3u.js
@@ -94,6 +94,10 @@ M3U.prototype.merge = function merge(m3u) {
 M3U.prototype.slice = function slice(start, end) {
   var m3u = this.clone();
 
+  if (start == null && end == null) {
+    return m3u;
+  }
+
   var len = m3u.items.PlaylistItem.length;
 
   start = !start || start < 0 ? 0 : start;
@@ -124,7 +128,7 @@ M3U.prototype.sliceSeconds = function slice(from, to) {
       }
     }
 
-    if (total >= to && end == null) {
+    if (total <= to && end == null) {
       end = i + 1;
       return true;
     }
@@ -147,6 +151,14 @@ M3U.prototype.sliceDates = function slice(from, to) {
     to = new Date(from.getTime() + to * 1000);
   }
 
+  if (!from) {
+    from = new Date(0);
+  }
+
+  if (!to) {
+    to = new Date();
+  }
+
   if (util.isDate(from) && util.isDate(to) && from > to) {
     throw 'target `to` date value, if available, must be greater than the `from` date value';
   }
@@ -167,8 +179,8 @@ M3U.prototype.sliceDates = function slice(from, to) {
       }
     }
 
-    if (current >= to && end == null) {
-      end = i + 1;
+    if (current > to && end == null) {
+      end = i;
       return true;
     }
   });
@@ -179,6 +191,7 @@ M3U.prototype.sliceDates = function slice(from, to) {
 M3U.prototype.toString = function toString() {
   var self   = this;
   var output = ['#EXTM3U'];
+
   Object.keys(this.properties).forEach(function(key) {
     var tagKey = propertyMap.findByKey(key);
     var tag = tagKey ? tagKey.tag : key;

--- a/m3u.js
+++ b/m3u.js
@@ -119,7 +119,7 @@ M3U.prototype.merge = function merge(m3u) {
   return this;
 };
 
-M3U.prototype.sliceIndex = M3U.prototype.slice = function slice(start, end) {
+M3U.prototype.slice = M3U.prototype.sliceIndex = function slice(start, end) {
   var m3u = this.clone();
 
   if (start == null && end == null) {
@@ -286,19 +286,19 @@ M3U.prototype.toString = function toString() {
   return output.join('\n') + '\n';
 };
 
-M3U.prototype.isVOD = function clone() {
+M3U.prototype.isVOD = function isVOD () {
   return this.get('foundEndlist') || this.get('playlistType') === 'VOD';
 };
 
-M3U.prototype.isLive = function clone() {
+M3U.prototype.isLive = function isLive () {
   return !this.isVOD();
 };
 
-M3U.prototype.clone = function clone() {
+M3U.prototype.clone = function clone () {
   return M3U.unserialize(this.serialize());
 };
 
-M3U.prototype.toJSON = function toJSON() {
+M3U.prototype.toJSON = function toJSON () {
   var object = this.serialize();
   object.properties.totalDuration = this.totalDuration();
   return object;

--- a/m3u.js
+++ b/m3u.js
@@ -179,7 +179,7 @@ M3U.prototype.sliceDates = function slice(from, to) {
       }
     }
 
-    if (current > to && end == null) {
+    if (current >= to && end == null) {
       end = i;
       return true;
     }

--- a/m3u.js
+++ b/m3u.js
@@ -105,7 +105,9 @@ M3U.prototype.slice = function slice(start, end) {
     end = len;
   }
 
+  // everytime you slice, the assumption here is to make the outputed playlist look like a VOD
   m3u.set('foundEndlist', true);
+
   m3u.items.PlaylistItem = m3u.items.PlaylistItem.slice(start, end);
 
   return m3u;

--- a/m3u.js
+++ b/m3u.js
@@ -101,8 +101,11 @@ M3U.prototype.slice = function slice(start, end) {
   var len = m3u.items.PlaylistItem.length;
 
   start = !start || start < 0 ? 0 : start;
-  end = end == null || end > len ? len : end;
+  if (end == null || end > len) {
+    end = len;
+  }
 
+  m3u.set('foundEndlist', true);
   m3u.items.PlaylistItem = m3u.items.PlaylistItem.slice(start, end);
 
   return m3u;
@@ -128,7 +131,7 @@ M3U.prototype.sliceSeconds = function slice(from, to) {
       }
     }
 
-    if (total <= to && end == null) {
+    if (total >= to && end == null) {
       end = i + 1;
       return true;
     }

--- a/m3u.js
+++ b/m3u.js
@@ -81,6 +81,8 @@ M3U.prototype.totalDuration = function totalDuration() {
   }, 0);
 };
 
+
+// todo: thought: I think concat() should return a clone, not self mutate.
 M3U.prototype.concat = function concat(m3u) {
   if (m3u.get('targetDuration') > this.get('targetDuration')) {
     this.set('targetDuration', m3u.get('targetDuration'));
@@ -94,6 +96,8 @@ M3U.prototype.concat = function concat(m3u) {
   return this;
 };
 
+// todo: thought: I think merge() should return a clone, not self mutate.
+// this one would break backward compatibility though
 M3U.prototype.merge = function merge(m3u) {
   var uri0 = ((m3u.items.PlaylistItem[0] || {}).properties || {}).uri;
 

--- a/m3u.js
+++ b/m3u.js
@@ -193,7 +193,7 @@ M3U.prototype.toString = function toString() {
   if (this.items.PlaylistItem.length) {
     output.push(this.items.PlaylistItem.map(itemToString).join('\n'));
 
-    if (this.get('playlistType') == null || this.get('playlistType') === 'VOD') {
+    if ((this.get('foundEndlist') && this.get('playlistType') == null) || this.get('playlistType') === 'VOD') {
       output.push('#EXT-X-ENDLIST');
     }
   } else {

--- a/m3u/AttributeList.js
+++ b/m3u/AttributeList.js
@@ -56,7 +56,7 @@ AttributeList.prototype.toString = function toString() {
 };
 
 AttributeList.prototype.serialize = function serialize() {
-  return this.attributes;
+  return JSON.parse(JSON.stringify(this.attributes));
 };
 
 AttributeList.unserialize = function unserialize(object) {

--- a/m3u/Item.js
+++ b/m3u/Item.js
@@ -31,9 +31,12 @@ Item.prototype.set = function set(key, value) {
 };
 
 Item.prototype.serialize = function serialize() {
+  var attrs = JSON.parse(JSON.stringify(this.properties));
+  attrs.date = attrs.date ? new Date(attrs.date) : attrs.date;
+
   return {
     attributes  : this.attributes.serialize(),
-    properties  : this.properties
+    properties  : attrs
   }
 };
 

--- a/parser.js
+++ b/parser.js
@@ -34,14 +34,23 @@ m3uParser.createStream = function(options) {
 
 m3uParser.prototype.parse = function parse(line) {
   line = line.trim();
+
   if (this.linesRead == 0) {
-    if (line != '#EXTM3U') {
+    var extm3uSkipped = false;
+
+    if (line != '#EXTM3U' && !this.options.lax) {
       return this.emit('error', new Error(
         'Non-valid M3U file. First line: ' + line
       ));
     }
+    if (line != '#EXTM3U' && this.options.lax) {
+      extm3uSkipped = true;
+    }
     this.linesRead++;
-    return true;
+
+    if (!extm3uSkipped) {
+      return true;
+    }
   }
 
   if (['', '#EXT-X-ENDLIST'].indexOf(line) > -1) {

--- a/parser.js
+++ b/parser.js
@@ -41,7 +41,12 @@ m3uParser.prototype.parse = function parse(line) {
     this.linesRead++;
     return true;
   }
-  if (['', '#EXT-X-ENDLIST'].indexOf(line) > -1) return true;
+
+  if (['', '#EXT-X-ENDLIST'].indexOf(line) > -1) {
+    this.m3u.set('foundEndlist', true);
+    return true;
+  }
+
   if (line.indexOf('#') == 0) {
     this.parseLine(line);
   } else {

--- a/parser.js
+++ b/parser.js
@@ -81,11 +81,19 @@ m3uParser.prototype['EXTINF'] = function parseInf(data) {
     this.currentItem.set('discontinuity', true);
     this.playlistDiscontinuity = false;
   }
+  if (this.playlistDate) {
+    this.currentItem.set('date', this.playlistDate);
+    this.playlistDate = null;
+  }
+};
+
+m3uParser.prototype['EXT-X-PROGRAM-DATE-TIME'] = function parseInf(data) {
+  this.playlistDate = new Date(data);
 };
 
 m3uParser.prototype['EXT-X-DISCONTINUITY'] = function parseInf() {
   this.playlistDiscontinuity = true;
-}
+};
 
 m3uParser.prototype['EXT-X-BYTERANGE'] = function parseByteRange(data) {
   this.currentItem.set('byteRange', data);
@@ -107,7 +115,7 @@ m3uParser.prototype['EXT-X-MEDIA'] = function(data) {
 
 m3uParser.prototype.parseAttributes = function parseAttributes(data) {
   data = data.split(NON_QUOTED_COMMA);
-  var self = this;
+
   return data.map(function(attribute) {
     var keyValue = attribute.split(/=(.+)/).map(function(str) {
       return str.trim();

--- a/test/m3u.test.js
+++ b/test/m3u.test.js
@@ -198,6 +198,7 @@ describe('m3u', function() {
   describe('writeLive', function() {
     it('should return a string not ending with #EXT-X-ENDLIST', function() {
       var m3u1 = getM3u();
+      m3u1.set('playlistType', 'EVENT');
       m3u1.addPlaylistItem({});
 
       var output = m3u1.toString();


### PR DESCRIPTION
## List of additions/changes

### parser
* added an `options` parameter to `createStream(options)`
  * __`options.lax`__ a `true/false` boolean which basically forgives the parsed text if it doesn't start by an `EXTM3U` tag, this is useful for merging many m3u8s into one, while tailing a large Live file.
  * __`options.beforeItemEmit()`__ a function hook which gets called before the emit of each `item` event, passing the `currentItem` as the 1st argument. The reason this was useful in my use case if because I had m3u8s without the program-date-time tag, which the .ts files were named using timestamps, so before each item emit, I doing something like this `currentItem.set('date', new Date(currentItem.get(uri)));`
* added __`parser.['EXT-X-PROGRAM-DATE-TIME']()`__, since `m3u.toString()` does output it if available but the parser ignores it.

### m3u
* added __`m3u.clone()`__ basically just returns a clone of the `m3u` object.
* added __`m3u.concat()`__ which behaves exactly like how `m3u.merge()` used to behave, basically just concats the playlist items.
* modified __`m3u.merge()`__ to do a real unique merge, using each `item.uri` as the identifier.
* added some slicing functions, which each returns a new `m3u` object with a slice of the PlaylistItems, also slicing a live m3u while using an end-range, will make the returned m3u as VOD, since the slice has an ending.
  * __`m3u.sliceIndex()`__, (alias __`m3u.slice()`__) slices based on the segments indices.
  * __`m3u.sliceSeconds()`__, slices based on the position of each segment on the timeline of video seconds duration.
  * __`m3u.sliceDates()`__ slices based on the position of each segment on the timeline of real time (depends on the `EXT-X-PROGRAM-DATE-TIME` tag of course, or a custom item.date being set via the `beforeItemEmit` hook)
* added 2 functions to keep track if an `ENDLIST` tag was actually found, then it's a `VOD` since `EXT-X-PLAYLIST-TYPE` is optional and might not be there.
  * __`m3u.isVOD()`__
  * __`m3u.isLive()`__ 

## Notes

* I think __`m3u.concat()`__ and __`m3u.merge()`__ should return a clone instead of mutating self - or we can change all the slicing functions, __`m3u.slice*()`__, to mutate self as well instead of returning a clone, let me know what you think.

## Tests

I think I covered all the things I added :), still a little shy but I will submit more as I move along.


