### PR TITLE
Add support for parsing EXT-X-PROGRAM-DATE-TIME

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -91,6 +91,10 @@ m3uParser.prototype['EXT-X-BYTERANGE'] = function parseByteRange(data) {
   this.currentItem.set('byteRange', data);
 };
 
+m3uParser.prototype['EXT-X-PROGRAM-DATE-TIME'] = function parseProgramDateTime(data) {
+  this.currentItem.set('date', data);
+};
+
 m3uParser.prototype['EXT-X-STREAM-INF'] = function(data) {
   this.addItem(new StreamItem(this.parseAttributes(data)));
 };

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -69,6 +69,17 @@ describe('parser', function() {
     });
   });
 
+  describe('#EXT-X-PROGRAM-DATE-TIME', function() {
+    it('should set date on currentItem', function() {
+      var parser = getParser();
+      var programDateTime = '2017-03-23T19:26:41.000+0000';
+
+      parser.EXTINF('4.5,');
+      parser['EXT-X-PROGRAM-DATE-TIME'](programDateTime);
+      parser.currentItem.get('date').should.eql(programDateTime);
+    });
+  });
+
   describe('#EXT-X-DISCONTINUITY', function() {
     it('should indicate discontinuation on subsequent playlist item', function() {
       var parser = getParser();


### PR DESCRIPTION
Makes the raw value of the `EXT-X-PROGRAM-DATE-TIME` available on a playlist item. I used the same property name as what was added in #2.