### PR TITLE
Allow add extra attributes in playlist items.

### DIFF
--- a/m3u/PlaylistItem.js
+++ b/m3u/PlaylistItem.js
@@ -14,7 +14,12 @@ PlaylistItem.create = function createPlaylistItem(data) {
 };
 
 PlaylistItem.prototype.toString = function toString() {
-  var output = [];
+  var attributes = this.attributes;
+  var output = Object.keys(attributes.serialize()).map(function(key) {
+    var tag = key.toUpperCase();
+    var value = attributes.getCoerced(key);
+    return value.length ? [tag, value].join(':') : tag;
+  });
   if (this.get('discontinuity')) {
     output.push('#EXT-X-DISCONTINUITY');
   }


### PR DESCRIPTION
This feature allow to add extra attributes to items in a playlist. E.i:
`playlist.items.PlaylistItem[lastIndex].attributes.attributes['#EXT-X-MDSTRM-CUE-POINT-OUT'] = "DURATION=#{Number(segment.cueOut.duration).toFixed 4},#{segment.cueOut.id}"`