### PR TITLE
Support for unknown boolean tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea/
+.DS_Store

--- a/m3u.js
+++ b/m3u.js
@@ -160,6 +160,9 @@ var coerce = {
     return parseInt(value, 10);
   },
   unknown: function coerceUnknown(value) {
+    if (value === undefined) {
+      return true;
+    }
     return value;
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "m3u8",
-    "version" : "0.0.6",
+    "version" : "0.0.7",
     "description" : "streaming m3u8 parser for Apple's HTTP Live Streaming protocol",
     "main" : "./parser.js",
     "keywords" : [

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -30,6 +30,13 @@ describe('parser', function() {
       parser.m3u.get('THIS-IS-A-TAG').should.eql('some value');
     });
 
+    it('should set true on m3u on unknown boolean tags', function() {
+        var parser = getParser();
+
+        parser.parseLine('#THIS-IS-A-BOOLEAN-TAG');
+        parser.m3u.get('THIS-IS-A-BOOLEAN-TAG').should.eql(true);
+    });
+
     it('should split on first colon only', function() {
       var parser = getParser();
 


### PR DESCRIPTION
Adds support for any boolean tags that are unknown. My particular use case was for EXT-X-INDEPENDENT-SEGMENTS, but this would allow for any other boolean tags that may be added future of the spec.