### PR TITLE
average-bandwidth and frame-rate attributes added as known ones

### DIFF
--- a/m3u.js
+++ b/m3u.js
@@ -165,19 +165,21 @@ var coerce = {
 };
 
 var dataTypes = {
-  iframesOnly    : 'boolean',
-  targetDuration : 'integer',
-  mediaSequence  : 'integer',
-  version        : 'integer'
+  iframesOnly         : 'boolean',
+  independentSegments : 'boolean',
+  targetDuration      : 'integer',
+  mediaSequence       : 'integer',
+  version             : 'integer'
 };
 
 var propertyMap = [
-  { tag: 'EXT-X-ALLOW-CACHE',    key: 'allowCache' },
-  { tag: 'EXT-X-I-FRAMES-ONLY',  key: 'iframesOnly' },
-  { tag: 'EXT-X-MEDIA-SEQUENCE', key: 'mediaSequence' },
-  { tag: 'EXT-X-PLAYLIST-TYPE',  key: 'playlistType' },
-  { tag: 'EXT-X-TARGETDURATION', key: 'targetDuration' },
-  { tag: 'EXT-X-VERSION',        key: 'version' }
+  { tag: 'EXT-X-ALLOW-CACHE',          key: 'allowCache' },
+  { tag: 'EXT-X-I-FRAMES-ONLY',        key: 'iframesOnly' },
+  { tag: 'EXT-X-INDEPENDENT-SEGMENTS', key: 'independentSegments' },
+  { tag: 'EXT-X-MEDIA-SEQUENCE',       key: 'mediaSequence' },
+  { tag: 'EXT-X-PLAYLIST-TYPE',        key: 'playlistType' },
+  { tag: 'EXT-X-TARGETDURATION',       key: 'targetDuration' },
+  { tag: 'EXT-X-VERSION',              key: 'version' }
 ];
 
 propertyMap.findByTag = function findByTag(tag) {

--- a/m3u/AttributeList.js
+++ b/m3u/AttributeList.js
@@ -4,24 +4,26 @@ var AttributeList = module.exports = function AttributeList(attributes) {
 };
 
 var dataTypes = AttributeList.dataTypes = {
-  'audio'      : 'quoted-string',
-  'autoselect' : 'boolean',
-  'bandwidth'  : 'decimal-integer',
-  'byterange'  : 'enumerated-string',
-  'codecs'     : 'quoted-string',
-  'default'    : 'boolean',
-  'duration'   : 'decimal-floating-point',
-  'forced'     : 'boolean',
-  'group-id'   : 'quoted-string',
-  'language'   : 'quoted-string',
-  'name'       : 'quoted-string',
-  'program-id' : 'decimal-integer',
-  'resolution' : 'decimal-resolution',
-  'subtitles'  : 'quoted-string',
-  'title'      : 'enumerated-string',
-  'type'       : 'enumerated-string',
-  'uri'        : 'quoted-string',
-  'video'      : 'quoted-string'
+  'audio'             : 'quoted-string',
+  'autoselect'        : 'boolean',
+  'bandwidth'         : 'decimal-integer',
+  'average-bandwidth' : 'decimal-integer',
+  'frame-rate'        : 'decimal-floating-point',
+  'byterange'         : 'enumerated-string',
+  'codecs'            : 'quoted-string',
+  'default'           : 'boolean',
+  'duration'          : 'decimal-floating-point',
+  'forced'            : 'boolean',
+  'group-id'          : 'quoted-string',
+  'language'          : 'quoted-string',
+  'name'              : 'quoted-string',
+  'program-id'        : 'decimal-integer',
+  'resolution'        : 'decimal-resolution',
+  'subtitles'         : 'quoted-string',
+  'title'             : 'enumerated-string',
+  'type'              : 'enumerated-string',
+  'uri'               : 'quoted-string',
+  'video'             : 'quoted-string'
 };
 
 AttributeList.prototype.mergeAttributes = function mergeAttributes(attributes) {

--- a/parser.js
+++ b/parser.js
@@ -41,7 +41,12 @@ m3uParser.prototype.parse = function parse(line) {
     this.linesRead++;
     return true;
   }
-  if (['', '#EXT-X-ENDLIST'].indexOf(line) > -1) return true;
+  switch(['#EXT-X-ENDLIST', ''].indexOf(line)) {
+    case 0:
+      this.m3u.set('playlistType', 'VOD');
+    case 1:
+      return true;
+  }
   if (line.indexOf('#') == 0) {
     this.parseLine(line);
   } else {


### PR DESCRIPTION
Hi,

   I added 2 known attributes 'average-bandwidth' and 'frame-rate' to stop messages like this:

Handling value: 2890800  for unknown key: average-bandwidth
Handling value: 30.000  for unknown key: frame-rate
Handling value: 1240800  for unknown key: average-bandwidth
Handling value: 30.000  for unknown key: frame-rate
Handling value: 965800  for unknown key: average-bandwidth
Handling value: 30.000  for unknown key: frame-rate
Handling value: 5090800  for unknown key: average-bandwidth
Handling value: 30.000  for unknown key: frame-rate

on manifest parsing